### PR TITLE
Add To Cart From Grant Page

### DIFF
--- a/app/assets/v2/js/grants/fund.js
+++ b/app/assets/v2/js/grants/fund.js
@@ -194,12 +194,14 @@ $(document).ready(function() {
   });
   $('.contribution_type select').trigger('change');
 
+  // TODO: convert add to cart to form and grab data from hidden inputs like this
   $('#js-fundGrant').submit(function(e) {
     e.preventDefault();
     var data = {};
     var form = $(this).serializeArray();
 
     $.each(form, function() {
+      console.log(this.name, this.value);
       data[this.name] = this.value;
     });
 

--- a/app/assets/v2/js/grants/fund.js
+++ b/app/assets/v2/js/grants/fund.js
@@ -194,14 +194,12 @@ $(document).ready(function() {
   });
   $('.contribution_type select').trigger('change');
 
-  // TODO: convert add to cart to form and grab data from hidden inputs like this
   $('#js-fundGrant').submit(function(e) {
     e.preventDefault();
     var data = {};
     var form = $(this).serializeArray();
 
     $.each(form, function() {
-      console.log(this.name, this.value);
       data[this.name] = this.value;
     });
 

--- a/app/assets/v2/js/grants/info.js
+++ b/app/assets/v2/js/grants/info.js
@@ -1,0 +1,7 @@
+$(document).ready(function() {
+
+    $('#js-addToCart-button').click(function(e) {
+        e.preventDefault();
+        console.log("Hello world");
+    });
+});

--- a/app/assets/v2/js/grants/info.js
+++ b/app/assets/v2/js/grants/info.js
@@ -7,7 +7,8 @@ $(document).ready(function() {
         event.preventDefault();
 
         const formData = objectifySerialized($(this).serializeArray());
-        console.log("Form data", formData);
+        addToCart(formData);
+        // console.log("CART", loadCart());
     });
 });
 
@@ -22,4 +23,37 @@ function objectifySerialized(data) {
     }
 
     return objectData;
+}
+
+function cartContainsGrantWithSlug(grantSlug) {
+    const cart = loadCart();
+    const slugList = cart.map(grant => {
+        return grant.grant_slug;
+    });
+
+    return slugList.includes(grantSlug);
+}
+
+function addToCart(grantData) {
+    if (cartContainsGrantWithSlug(grantData.grant_slug)) {
+        return;
+    }
+
+    let cartList = loadCart()
+    cartList.push(grantData);
+    setCart(cartList);
+}
+
+function loadCart() {
+    let cartList = localStorage.getItem('grants_cart');
+
+    if (!cartList) {
+        return [];
+    }
+
+    return JSON.parse(cartList);
+}
+
+function setCart(list) {
+    localStorage.setItem('grants_cart', JSON.stringify(list));
 }

--- a/app/assets/v2/js/grants/info.js
+++ b/app/assets/v2/js/grants/info.js
@@ -1,7 +1,25 @@
+
+// DOCUMENT
+
 $(document).ready(function() {
 
-    $('#js-addToCart-button').click(function(e) {
-        e.preventDefault();
-        console.log("Hello world");
+    $('#js-addToCart-form').submit(function(event) {
+        event.preventDefault();
+
+        const formData = objectifySerialized($(this).serializeArray());
+        console.log("Form data", formData);
     });
 });
+
+// HELPERS
+
+function objectifySerialized(data) {
+    let objectData = {};
+
+    for (let i = 0; i < data.length; i++) {
+        const item = data[i];
+        objectData[item.name] = item.value;
+    }
+
+    return objectData;
+}

--- a/app/grants/templates/grants/detail/index.html
+++ b/app/grants/templates/grants/detail/index.html
@@ -73,6 +73,7 @@
   <script src="{% static "v2/js/status.js" %}"></script>
   <script src="{% static "v2/js/pages/tabs.js" %}"></script>
   <script src="{% static "v2/js/grants/index.js" %}"></script>
+  <script src="{% static "v2/js/grants/info.js" %}"></script>
   <script src="{% static "v2/js/grants/compiledSplitter.js" %}"></script>
   <script src="{% static "v2/js/grants/compiledSubscriptionContract0.js" %}"></script>
   <script src="{% static "v2/js/grants/compiledSubscriptionContract1.js" %}"></script>

--- a/app/grants/templates/grants/detail/info.html
+++ b/app/grants/templates/grants/detail/info.html
@@ -156,9 +156,20 @@
           </button>
         </a>
       {% else %}
-        <button class="btn btn-gc-blue button--full shadow-none font-weight-bold py-3" id='js-addToCart-button'>
-          Add To Cart
-        </button>
+        <form id="js-addToCart-form">
+          <input type="hidden" id="grant_id" name="grant_id" value="{{ grant.id }}">
+          <input type="hidden" id="grant_slug" name="grant_slug" value="{{ grant.slug }}">
+          <input type="hidden" id="grant_title" name="grant_title" value="{{ grant.title }}">
+          <input type="hidden" id="grant_contract_version" name="grant_contract_version" value="{{ grant.contract_version }}">
+          <input type="hidden" id="grant_contract_address" name="grant_contract_address" value="{{ grant.contract_address }}">
+          <input type="hidden" id="grant_token_symbol" name="grant_token_symbol" value="{{ grant.grant.token_symbol }}">
+          <input type="hidden" id="grant_admin_address" name="grant_admin_address" value="{{ grant.admin_address }}">
+          <input type="hidden" id="grant_logo" name="grant_logo" value="{% if grant.logo and grant.logo.url %}{{ grant.logo.url }}{% else %}{% with grant_logo='v2/images/grants/logos/' id=grant.id|modulo:3 %} {% static grant_logo|addstr:id|add:'.png' %} {% endwith %} {% endif %}">
+          <input type="hidden" id="grant_image_css" name="grant_image_css" value="{{ grant.image_css }}">
+          <button class="btn btn-gc-blue button--full shadow-none font-weight-bold py-3" id='js-addToCart-button'>
+            Add To Cart
+          </button>
+        </form>
       {% endif %}
 
     {% endif %}

--- a/app/grants/templates/grants/detail/info.html
+++ b/app/grants/templates/grants/detail/info.html
@@ -156,11 +156,9 @@
           </button>
         </a>
       {% else %}
-        <a href="{% url 'grants:fund' grant.id grant.slug %}">
-          <button class="btn btn-gc-blue button--full shadow-none font-weight-bold py-3">
-            Fund this Grant
-          </button>
-        </a>
+        <button class="btn btn-gc-blue button--full shadow-none font-weight-bold py-3" id='js-addToCart-button'>
+          Add To Cart
+        </button>
       {% endif %}
 
     {% endif %}


### PR DESCRIPTION
From the grants page, "Fund This Grant" is now "Add To Cart".

When a user presses this button, a bunch of grant data is dumped into local storage for this grant. The cart page can access the data from this store to render the cart.

Uncomment [line 11](https://github.com/ScopeLift/gitcoin-web/pull/2/files#diff-33b65a59c3e7ea0a651605a79a7af6c5R11) to get a sense of what data is included.

closes #3 