### PR TITLE
Workable Scrolling Mechanics For Side Cart + Recurring Link

### DIFF
--- a/app/assets/v2/css/grants/side-cart.css
+++ b/app/assets/v2/css/grants/side-cart.css
@@ -1,4 +1,14 @@
 .grant-side-cart {
     background-color: white;
     border-left: lightgray 2px solid;
-  }
+}
+
+@media only screen and (min-width: 768px) {
+    #side-cart {
+        position: fixed;
+        top: 0;
+        right: 0;
+        height: 100vh;
+        overflow-y: scroll;
+    }
+}

--- a/app/assets/v2/js/grants/funding.js
+++ b/app/assets/v2/js/grants/funding.js
@@ -135,8 +135,11 @@ function showSideCart() {
         toggleSideCart();
     }
 
-    const cartTop = $('#side-cart').position().top;
-    window.scrollTo(0, cartTop);
+    // Scroll To top on mobile
+    if (window.innerWidth < 768) {
+        const cartTop = $('#side-cart').position().top;
+        window.scrollTo(0, cartTop);
+    }
 }
 
 function hideSideCart() {

--- a/app/grants/templates/grants/detail/funding.html
+++ b/app/grants/templates/grants/detail/funding.html
@@ -93,16 +93,23 @@
                         ADD TO CART
                     </button>
                 </form>
+                <div class="" style="text-align: center;">
+                </div>
             {% endif %}
 
             {% endif %}
 
             {% if not is_team_member %}
-            <div class="mt-2 pt-2 float-right mb-1">
-            {% if grant.negative_voting_enabled %}
-                <a id="negative_fund" href="{% url 'grants:fund' grant.id grant.slug %}?direction=-">Negative Fund <i class="fas fa-user-minus"></i></a>
-            {% endif %} 
-            <a  id="flag" href="#" data-href="/grants/flag/{{grant.id}}">Flag <i class="far fa-flag"></i></a>
+            <div class="pt-2 mb-1">
+                <div class="float-left">
+                    <a href="/grants/{{grant.id}}/{{grant.slug}}/fund">Give Recurring</a>
+                </div>
+                <div class="float-right">
+                    {% if grant.negative_voting_enabled %}
+                        <a id="negative_fund" href="{% url 'grants:fund' grant.id grant.slug %}?direction=-">Negative Fund <i class="fas fa-user-minus"></i></a>
+                    {% endif %}
+                    <a  id="flag" href="#" data-href="/grants/flag/{{grant.id}}">Flag <i class="far fa-flag"></i></a>
+                </div>
             </div>
             {% endif %}
         </div>

--- a/app/grants/templates/grants/detail/side-cart.html
+++ b/app/grants/templates/grants/detail/side-cart.html
@@ -31,7 +31,7 @@
             <div>You can add more grants to fund multiple grants at once!</div>
         </div>
     </div>
-    <div class="mt-5">
+    <div class="mt-5 mb-3">
         <form action="/grants/cart">
             <button class="btn btn-gc-blue button--full shadow-none font-weight-bold py-3">
                 <i style="width: 14px;" class="fab fa-ethereum mr-2 text-center"></i>

--- a/app/grants/templates/grants/fund.html
+++ b/app/grants/templates/grants/fund.html
@@ -159,9 +159,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                     <div class="row">
                       <div class="col-12 col-sm-8 font-body">
                         <label class="form__label">{% trans "Contribution Type" %}</label>
-                        <select name="recurring_or_not" id="recurring_or_not" class="js-select2" style="width: 100%">
-                          <option value="once" selected="selected">{% trans "One Time" %}</option>
-                          <option value="recurring">{% trans "Recurring" %}</option>
+                        <select name="recurring_or_not" id="recurring_or_not" class="js-select2" style="width: 100%" disabled="true">
+                          <option value="recurring" selected="selected">{% trans "Recurring" %}</option>
                         </select>
                       </div>
 


### PR DESCRIPTION
closes #29 

* When in mobile, the side cart still covers the page
  and scrolls as normal; scrolling jumps to top of the
  cart when an item is added
* When non-mobile, the side cart is fixed on the right side
  and extends the full height of the page; it scrolls
  independent of the rest of the page, so that top and bottom
  are always accessible regardless of how many elements are in the
  cart and how big the window is
* Add a link to the old funding page for the option to give recurring donations