### PR TITLE
POST request setup

### DIFF
--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -113,7 +113,7 @@ Vue.component('grants-cart', {
 
       // Generate array of objects containing donation info from cart
       let gitcoinFactor = 100 * this.gitcoinFactor;
-      const donations = this.grantData.map((grant) => {
+      const donations = this.grantData.map((grant, index) => {
         const tokenDetails = this.getTokenByName(grant.grant_donation_currency);
         const amount = this.toWeiString(grant.grant_donation_amount, tokenDetails.decimals, 100 - gitcoinFactor);
 
@@ -121,7 +121,9 @@ Vue.component('grants-cart', {
           token: tokenDetails.addr,
           amount,
           dest: grant.grant_admin_address,
-          name: grant.grant_donation_currency
+          name: grant.grant_donation_currency, // token abbreviation, e.g. DAI
+          grant, // all grant data from localStorage
+          comment: this.comments[index] // comment left by donor to grant owner
         };
       });
 
@@ -130,11 +132,33 @@ Vue.component('grants-cart', {
         const tokenDetails = this.getTokenByName(token);
         const amount = this.toWeiString(this.donationsToGitcoin[token], tokenDetails.decimals);
 
+        // TBD: Confirm these are suitable values for the automatic Gitcoin donations
+        const gitcoinGrantInfo = {
+          // Manually fill this in so we can access it for the POST requests.
+          // We use empty strings for fields that are not needed here
+          grant_admin_address: gitcoinAddress,
+          grant_contract_address: '',
+          grant_contract_version: '',
+          grant_donation_amount: this.donationsToGitcoin[token],
+          grant_donation_clr_match: '',
+          grant_donation_currency: token,
+          grant_donation_num_rounds: 1,
+          grant_id: '',
+          grant_image_css: '',
+          grant_logo: '',
+          grant_slug: '',
+          grant_title: '',
+          grant_token_address: '0x0000000000000000000000000000000000000000',
+          grant_token_symbol: ''
+        };
+
         donations.push({
           amount,
           token: tokenDetails.addr,
           dest: gitcoinAddress,
-          name: token
+          name: token, // token abbreviation, e.g. DAI
+          grant: gitcoinGrantInfo, // equivalent to grant data from localStorage
+          comment: '' // comment left by donor to grant owner
         });
       });
       return donations;
@@ -314,6 +338,11 @@ Vue.component('grants-cart', {
         await window.ethereum.enable();
         const userAddress = (await web3.eth.getAccounts())[0]; // Address of current user
 
+        const txHash = 'bulk donation txHash would go here';
+
+        this.postToDatabase(txHash, userAddress);
+        return;
+
         // Get list of tokens user is donating with
         const selectedTokens = Object.keys(this.donationsToGrants);
 
@@ -403,6 +432,8 @@ Vue.component('grants-cart', {
       const bulkTransaction = new web3.eth.Contract(bulkCheckoutAbi, bulkCheckoutAddress);
       const donationInputs = this.donationInputs.map(donation => {
         delete donation.name;
+        delete donation.grant;
+        delete donation.comment;
         return donation;
       });
 
@@ -411,8 +442,9 @@ Vue.component('grants-cart', {
         .donate(donationInputs)
         .send({ from: userAddress, gas: this.donationInputsGasLimit, value: this.donationInputsEthAmount })
         .on('transactionHash', (txHash) => {
-          console.log('Donation transaction: ', txHash);
+          console.log('Donation transaction hash: ', txHash);
           indicateMetamaskPopup(true);
+          this.postToDatabase(txHash, userAddress);
         })
         .on('confirmation', (confirmationNumber, receipt) => {
           // TODO?
@@ -421,6 +453,95 @@ Vue.component('grants-cart', {
           // If the transaction was rejected by the network with a receipt, the second parameter will be the receipt.
           this.handleError(error);
         });
+    },
+
+    postToDatabase(txHash, userAddress) {
+      // this.donationInputs is the array used for bulk donations
+      // We loop through each donation and POST the required data
+      const donations = this.donationInputs;
+
+      for (let i = 0; i < donations.length; i += 1) {
+        console.log('============================================================');
+        console.log(`DONATION ${i}`);
+        // Get URL to POST to
+        const donation = donations[i];
+        const grantId = donation.grant.grant_id;
+        const grantSlug = donation.grant.grant_slug;
+        const url = `/grants/${grantId}/${grantSlug}/fund`;
+
+        console.log('input data', donation);
+
+        // Get token information
+        const tokenName = donation.grant.grant_donation_currency;
+        const tokenDetails = this.getTokenByName(tokenName);
+
+        // Gitcoin uses the zero address to represent ETH, but the contract does not. Therefore we
+        // get the value of denomination and token_address using the below logic instead of
+        // using tokenDetails.addr
+        const isEth = tokenName === 'ETH';
+        const tokenAddress = isEth ? '0x0000000000000000000000000000000000000000' : tokenDetails.addr;
+
+        // Replace undefined comments with empty strings
+        const comment = donation.comment === undefined ? '' : donation.comment;
+
+        // Configure saveSubscription payload
+        const saveSubscriptionPayload = {
+          admin_address: donation.grant.grant_admin_address,
+          amount_per_period: donation.grant.grant_donation_amount,
+          comment,
+          contract_address: donation.grant.grant_contract_address,
+          contract_version: donation.grant.grant_contract_version,
+          contributor_address: userAddress,
+          csrfmiddlewaretoken: undefined, // TBD: Where is this from?
+          denomination: tokenAddress,
+          frequency_count: '1',
+          frequency_unit: 'rounds',
+          gas_price: undefined, // TBD: Do we need this? Simplest way to get it without waiting for receipt?
+          'gitcoin-grant-input-amount': this.gitcoinFactorRaw, // TBD: I'm assuming this is the percentage to Gitcoin
+          gitcoin_donation_address: gitcoinAddress,
+          grant_id: grantId,
+          hide_wallet_address: this.hideWalletAddress,
+          match_direction: '+',
+          network,
+          num_periods: '1',
+          real_period_seconds: 0,
+          recurring_or_not: 'once',
+          signature: '',
+          splitter_contract_address: bulkCheckoutAddress,
+          sub_new_approve_tx_id: txHash, // TBD: This txhash is our bulk donation hash, not an approval tx. But I'd think we want our txHash here somewhere
+          subscription_hash: '',
+          token_address: tokenAddress,
+          token_symbol: tokenName
+        };
+
+        // Configure saveSplitTx payload
+        const saveSplitTxPayload = {
+          csrfmiddlewaretoken: undefined, // TBD: Where is this from?
+          signature: 'onetime',
+          confirmed: false, // TBD: Is this sufficient? Who/when/how should it be updated in DB?
+          split_tx_id: txHash, // TBD: This txhash is our bulk donation hash which seems to be what we want here
+          sub_new_approve_tx_id: undefined, // TBD: Unlike saveSubscription, we have our txHash above so maybe this is unnecessary?
+          subscription_hash: 'onetime'
+        };
+
+        console.log('saveSubscriptionPayload: ', saveSubscriptionPayload);
+        console.log('saveSplitTxPayload: ', saveSplitTxPayload);
+
+        continue;
+        // Define parameter objects for POST request
+        const saveSubscriptionParams = {
+          body: saveSubscriptionPayload,
+          method: 'POST'
+        };
+        const saveSplitTxParams = {
+          body: saveSplitTxPayload,
+          method: 'POST'
+        };
+
+        // Send request
+        fetch(url, saveSubscriptionParams).catch(err => this.handleError(err));
+        fetch(url, saveSplitTxParams).catch(err => this.handleError(err));
+      }
     },
 
     sleep(ms) {

--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -338,11 +338,6 @@ Vue.component('grants-cart', {
         await window.ethereum.enable();
         const userAddress = (await web3.eth.getAccounts())[0]; // Address of current user
 
-        const txHash = 'bulk donation txHash would go here';
-
-        this.postToDatabase(txHash, userAddress);
-        return;
-
         // Get list of tokens user is donating with
         const selectedTokens = Object.keys(this.donationsToGrants);
 
@@ -429,8 +424,9 @@ Vue.component('grants-cart', {
 
     sendDonationTx(userAddress) {
       // Configure our donation inputs
+      // We use parse and stringify to avoid mutating this.donationInputs since we use it later
       const bulkTransaction = new web3.eth.Contract(bulkCheckoutAbi, bulkCheckoutAddress);
-      const donationInputs = this.donationInputs.map(donation => {
+      const donationInputs = JSON.parse(JSON.stringify(this.donationInputs)).map(donation => {
         delete donation.name;
         delete donation.grant;
         delete donation.comment;
@@ -460,6 +456,7 @@ Vue.component('grants-cart', {
       // We loop through each donation and POST the required data
       const donations = this.donationInputs;
 
+      console.log('donationInputs', this.donationInputs);
       for (let i = 0; i < donations.length; i += 1) {
         console.log('============================================================');
         console.log(`DONATION ${i}`);
@@ -527,7 +524,6 @@ Vue.component('grants-cart', {
         console.log('saveSubscriptionPayload: ', saveSubscriptionPayload);
         console.log('saveSplitTxPayload: ', saveSplitTxPayload);
 
-        continue;
         // Define parameter objects for POST request
         const saveSubscriptionParams = {
           body: saveSubscriptionPayload,
@@ -539,8 +535,20 @@ Vue.component('grants-cart', {
         };
 
         // Send request
-        fetch(url, saveSubscriptionParams).catch(err => this.handleError(err));
-        fetch(url, saveSplitTxParams).catch(err => this.handleError(err));
+        fetch(url, saveSubscriptionParams)
+          .then(data => console.log('data, saveSubscription', data))
+          .then(res => console.log('res, saveSubscription', res))
+          .catch(err => {
+            console.log('error, saveSubscription');
+            this.handleError(err);
+          });
+        fetch(url, saveSplitTxParams)
+          .then(data => console.log('data, saveSplitTx', data))
+          .then(res => console.log('res, saveSplitTx', res))
+          .catch(err => {
+            console.log('error, saveSplitTx');
+            this.handleError(err);
+          });
       }
     },
 

--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -494,8 +494,8 @@ Vue.component('grants-cart', {
           denomination: tokenAddress,
           frequency_count: 1,
           frequency_unit: 'rounds',
-          gas_price: 0, // TBD: Do we need this? Simplest way to get it without waiting for receipt?
-          'gitcoin-grant-input-amount': this.gitcoinFactorRaw, // TBD: I'm assuming this is the percentage to Gitcoin
+          gas_price: 0, // TBD: Do we need a real value here? Simplest way to get it without waiting for receipt?
+          'gitcoin-grant-input-amount': this.gitcoinFactorRaw, // TBD: It seems this is the percentage to Gitcoin
           gitcoin_donation_address: gitcoinAddress,
           grant_id: grantId,
           hide_wallet_address: this.hideWalletAddress,
@@ -506,7 +506,7 @@ Vue.component('grants-cart', {
           recurring_or_not: 'once',
           signature: '',
           splitter_contract_address: bulkCheckoutAddress,
-          sub_new_approve_tx_id: txHash, // TBD: This txhash is our bulk donation hash, not an approval tx. But I'd think we want our txHash here somewhere
+          sub_new_approve_tx_id: txHash, // TBD: This txhash is our bulk donation hash, not an approval tx. But I think we want that tx hash here anyway?
           subscription_hash: '',
           token_address: tokenAddress,
           token_symbol: tokenName
@@ -518,7 +518,7 @@ Vue.component('grants-cart', {
           signature: 'onetime',
           confirmed: false, // TBD: Is this sufficient? Who/when/how should it be updated in DB?
           split_tx_id: txHash, // TBD: This txhash is our bulk donation hash which seems to be what we want here
-          sub_new_approve_tx_id: '', // TBD: Unlike saveSubscription, we have our txHash above so maybe this is unnecessary?
+          sub_new_approve_tx_id: txHash, // TBD: A txhash is also required here, so use the same one?
           subscription_hash: 'onetime'
         });
 
@@ -542,19 +542,19 @@ Vue.component('grants-cart', {
           body: saveSplitTxPayload
         };
 
-        // Send request
+        // Send saveSubscription request
         fetch(url, saveSubscriptionParams)
-          .then(data => console.log('data, saveSubscription', data))
-          .then(res => console.log('res, saveSubscription', res))
+          .then(res => {
+            console.log('res, saveSubscription', res);
+            // Once we get a response we can send the saveSplitTx request, since this is
+            // dependent on the first one
+            fetch(url, saveSplitTxParams)
+              .then(res => console.log('res, saveSplitTx', res))
+              .catch(err => {
+                this.handleError(err);
+              });
+          })
           .catch(err => {
-            console.log('error, saveSubscription');
-            this.handleError(err);
-          });
-        fetch(url, saveSplitTxParams)
-          .then(data => console.log('data, saveSplitTx', data))
-          .then(res => console.log('res, saveSplitTx', res))
-          .catch(err => {
-            console.log('error, saveSplitTx');
             this.handleError(err);
           });
       }

--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -482,7 +482,7 @@ Vue.component('grants-cart', {
         const comment = donation.comment === undefined ? '' : donation.comment;
 
         // Configure saveSubscription payload
-        const saveSubscriptionPayload = {
+        const saveSubscriptionPayload = new URLSearchParams({
           admin_address: donation.grant.grant_admin_address,
           amount_per_period: donation.grant.grant_donation_amount,
           comment,
@@ -509,29 +509,36 @@ Vue.component('grants-cart', {
           subscription_hash: '',
           token_address: tokenAddress,
           token_symbol: tokenName
-        };
+        });
 
         // Configure saveSplitTx payload
-        const saveSplitTxPayload = {
+        const saveSplitTxPayload = new URLSearchParams({
           csrfmiddlewaretoken: undefined, // TBD: Where is this from?
           signature: 'onetime',
           confirmed: false, // TBD: Is this sufficient? Who/when/how should it be updated in DB?
           split_tx_id: txHash, // TBD: This txhash is our bulk donation hash which seems to be what we want here
           sub_new_approve_tx_id: undefined, // TBD: Unlike saveSubscription, we have our txHash above so maybe this is unnecessary?
           subscription_hash: 'onetime'
-        };
+        });
 
         console.log('saveSubscriptionPayload: ', saveSubscriptionPayload);
         console.log('saveSplitTxPayload: ', saveSplitTxPayload);
 
+        // Configure headers
+        const headers = {
+          'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+        };
+
         // Define parameter objects for POST request
         const saveSubscriptionParams = {
-          body: saveSubscriptionPayload,
-          method: 'POST'
+          method: 'POST',
+          headers,
+          body: saveSubscriptionPayload
         };
         const saveSplitTxParams = {
-          body: saveSplitTxPayload,
-          method: 'POST'
+          method: 'POST',
+          headers,
+          body: saveSplitTxPayload
         };
 
         // Send request

--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -455,6 +455,7 @@ Vue.component('grants-cart', {
       // this.donationInputs is the array used for bulk donations
       // We loop through each donation and POST the required data
       const donations = this.donationInputs;
+      const csrfmiddlewaretoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
 
       console.log('donationInputs', this.donationInputs);
       for (let i = 0; i < donations.length; i += 1) {
@@ -489,7 +490,7 @@ Vue.component('grants-cart', {
           contract_address: donation.grant.grant_contract_address,
           contract_version: donation.grant.grant_contract_version,
           contributor_address: userAddress,
-          csrfmiddlewaretoken: undefined, // TBD: Where is this from?
+          csrfmiddlewaretoken,
           denomination: tokenAddress,
           frequency_count: '1',
           frequency_unit: 'rounds',
@@ -513,7 +514,7 @@ Vue.component('grants-cart', {
 
         // Configure saveSplitTx payload
         const saveSplitTxPayload = new URLSearchParams({
-          csrfmiddlewaretoken: undefined, // TBD: Where is this from?
+          csrfmiddlewaretoken,
           signature: 'onetime',
           confirmed: false, // TBD: Is this sufficient? Who/when/how should it be updated in DB?
           split_tx_id: txHash, // TBD: This txhash is our bulk donation hash which seems to be what we want here

--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -492,16 +492,16 @@ Vue.component('grants-cart', {
           contributor_address: userAddress,
           csrfmiddlewaretoken,
           denomination: tokenAddress,
-          frequency_count: '1',
+          frequency_count: 1,
           frequency_unit: 'rounds',
-          gas_price: undefined, // TBD: Do we need this? Simplest way to get it without waiting for receipt?
+          gas_price: 0, // TBD: Do we need this? Simplest way to get it without waiting for receipt?
           'gitcoin-grant-input-amount': this.gitcoinFactorRaw, // TBD: I'm assuming this is the percentage to Gitcoin
           gitcoin_donation_address: gitcoinAddress,
           grant_id: grantId,
           hide_wallet_address: this.hideWalletAddress,
           match_direction: '+',
           network,
-          num_periods: '1',
+          num_periods: 1,
           real_period_seconds: 0,
           recurring_or_not: 'once',
           signature: '',
@@ -518,7 +518,7 @@ Vue.component('grants-cart', {
           signature: 'onetime',
           confirmed: false, // TBD: Is this sufficient? Who/when/how should it be updated in DB?
           split_tx_id: txHash, // TBD: This txhash is our bulk donation hash which seems to be what we want here
-          sub_new_approve_tx_id: undefined, // TBD: Unlike saveSubscription, we have our txHash above so maybe this is unnecessary?
+          sub_new_approve_tx_id: '', // TBD: Unlike saveSubscription, we have our txHash above so maybe this is unnecessary?
           subscription_hash: 'onetime'
         });
 


### PR DESCRIPTION
Currently a WIP. Once complete will close #35 

### Current status
- As we've already been doing, we send the bulk donation transaction in `cart.js` with a function called `sendDonationTx()`. This sends all donations (i.e. donations in cart + computed donations to Gitcoin) in one transaction using the BulkCheckout contract
- Once we receive a tx hash for the bulk donations, we call a new function called `postToDatabase()`
- This function loops through the array of all donations we just sent and POSTs the appropriate data
- The lines `const saveSubscriptionPayload = ...` and `const saveSplitTxPaylod = ...` are where we configure the payloads for each request. The values are based on what was observed from the current system, and there are plenty of TBDs with questions to answer (described in the next section)
- We send the POST requests at the end of this `postToDatabase()` function
- Let's define two categories of requests: The "Standard Requests" for the items explicitly listed in the cart, and the "Gitcoin Requests" for the automatic donations that are e.g. 5% of the selected grants

### Problems / Questions

1. For the "Gitcoin Requests", the requests fail with `404 Not Found`. This is expected because currently for these donations there is no grant ID or grant slug, and therefore we current POST to the non-existant endpoint `/grants///fund`. Can these be skipped, and if not how should these be handled?

2. For the "Standard Requests", the POST calls all succeed. But there's a few questions to answer here:
    1. We need to confirm that the parameters in `saveSubscriptionPayload` are correct. Just search for this variable name in `cart.js` and you'll find the object.
    2. We need to confirm that the parameters in `saveSplitTxPayload` are correct. Just search for this variable name in `cart.js` and you'll find the object.
    3. It seems the `saveSplitTx` request is dependent on the `saveSubscription` request. Previously this was ok because of the multiple transactions. However, sending these simultaneously can fail if `saveSubscription` does not create the subscription object before `saveSplitTx` tries to access it. Potential solutions:
        1. Send `saveSplitTx` after `saveSubscription` returns. Downside: `saveSubscription` takes ~1 minute to return, so this is pretty bad UX, and if the browser is closed the request will not be sent (this is what is currently implemented).
        2. Send `saveSubscription` immediately before the first approval tx prompt, and send `saveSplitTx` after the final bulk donation tx is sent. This seems to be similar what is currently done, and the time delay seems to be sufficient to prevent `saveSplitTx` from erroring
        3. Some other TBD solution